### PR TITLE
Data cue

### DIFF
--- a/index.html
+++ b/index.html
@@ -542,7 +542,7 @@
 
         <li>Track Attributes for sourced Text Tracks
           <p>
-            WebM has defined how to store WebVTT [[WEBVTT]] files in WebM [[WEBM]][[WEBVTT-WEBM]]. Sourcing text tracks from WebM is different for chapter tracks from tracks of other kinds and is explained below the table.
+            WebM has defined how to store WebVTT [[WEBVTT]] files in WebM [[WebM]][[WEBVTT-WEBM]]. Sourcing text tracks from WebM is different for chapter tracks from tracks of other kinds and is explained below the table.
           </p>
           <table>
             <thead>
@@ -681,7 +681,7 @@
               </td>
             </tr>
           </table>
-          <p class='note'>Other Matroska container format's text tracks can also be mapped to TextTrackCue objects. These will be created as DataCue objects with 'id', 'startTime', 'endTime', and 'pauseOnExit' attributes filled identically to the VTTCue objects, and the 'text' attribute containing the Block's data.
+          <p class='note'>Other Matroska container format's text tracks can also be mapped to TextTrackCue objects. These will be created as DataCue objects [[HTML5]] with 'id', 'startTime', 'endTime', and 'pauseOnExit' attributes filled identically to the VTTCue objects, and the 'data' attribute containing the Block's data.
           </p>
         </li>
       </ol>


### PR DESCRIPTION
Fix use of 'data' attribute for Matroska non-WebVTT text tracks.
Also fix the WebM reference.
