### PR TITLE
Defined exposing SCTE 27 subtitles with DataCue

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
               <td>
                 <ul>
                   <li>"captions": if a "Caption Service Descriptor section" is present in a video elementary stream of stream type "0x02" and its 'cc_type' is 1 (True)</li><!-- see http://www.etherguidesystems.com/help/sdos/atsc/semantics/descriptors/CaptionService.aspx -->
-                  <li>"subtitles": if the stream type value is "0x82"</li>
+                  <li>"subtitles": if the stream type value is "0x82" and the user agent can render MPEG-2 subtitles [[SCTE27]]</li>
                   <li>"metadata": otherwise</li>
                 </ul>
               </td>
@@ -419,8 +419,44 @@
               <p>
               <li> Subtitles cues
                 <p>
-                  MPEG-2 subtitles are in the SCTE 27 format [[SCTE27]] so cues on an MPEG-2 subtitle text track require an as yet to be specified SCTE27Cue format to expose them, unless browsers want to map the SCTE 27 features into a WebVTTCue. This mapping process has not been defined.
+                  Cues on an MPEG-2 subtitles text track are created as DataCue objects [[HTML5]]. MPEG-2 subtitle data is in the SCTE 27 format [[SCTE27]]. Each 'section' in an elementary stream identified as a subtitles text track creates a DataCue object with TexTrackCue attributes sourced as follows:
                 </p>
+                <table>
+                  <thead>
+                    <th>Attribute</th>
+                    <th>How to source its value</th>
+                  </thead>
+                  <tr>
+                    <th>id</th>
+                    <td>
+                      Decimal representation of the 'table_id' in the first 8 bits of the 'section' data.
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>startTime</th>
+                    <td>
+                      The time, in the HTML media resource timeline, that corresponds to the 'display_in_PTS' field in the section data. 
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>endTime</th>
+                    <td>
+                      The sum of the startTime and the 'display_duration' field in the section data expressed in seconds.
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>pauseOnExit</th>
+                    <td>
+                      'false'
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>data</th>
+                    <td>
+                      The 'section_length' number of bytes immediately following the 'section_length' field in the 'section'.
+                    </td>
+                  </tr>
+                </table>
               </li>
               </p> 
             </ol>


### PR DESCRIPTION
Changes to use DataCue for exposing SCTE 27 subtitles. This involves changes in: item 3 - setting kind, item 5c - subtitle cues
