### PR TITLE
Add text to set @label from mpeg-2ts data.

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@
             <tr>
               <th>label</th>
               <td>
-                The empty string.
+                The DOMString representation of the 'component_name_string' field in the 'component_name_descriptor' [[ATSC65]] found immediately after the 'ES_info_length' field in the Program Map Table [[MPEG2TS]]. The empty string if the 'component_name_descriptor' is not present.
               </td>
             </tr>
             <tr>
@@ -351,7 +351,7 @@
             <tr>
               <th>label</th>
               <td>
-                The empty string.
+                The DOMString representation of the 'component_name_string' field in the 'component_name_descriptor' [[ATSC65]] found immediately after the 'ES_info_length' field in the Program Map Table [[MPEG2TS]]. The empty string if the 'component_name_descriptor' is not present.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
I've discovered that MPEG-2 TS has the 'component_name_descriptor' that provides a textual tag for a component (i.e. elementary stream) in a MPEG-2 transport stream. I've added text for mapping this descriptor to @label.
