### PR TITLE
Fix duplicate definitions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,7 +415,7 @@
             </tr>
           </table>
         </li>
-        <li><p><dfn id='MPEG2TS-TT'>Mapping text track content into text track cues</dfn></p>
+        <li><p><dfn id='MPEG2TS-TT'>Mapping text track content into text track cues for MPEG-2 TS</dfn></p>
           <p>
             MPEG-2 transport streams may contain data that should be exposed as cues on 'captions', 'subtitles' or 'metadata' text tracks. No data is defined that equates to 'descriptions' or 'chapters' text track cues.
           </p>
@@ -655,7 +655,7 @@
             </tr>
           </table>
         </li>
-        <li><p><dfn id='ISOBMFF-TT'>Mapping text track content into text track cues</dfn></p>
+        <li><p><dfn id='ISOBMFF-TT'>Mapping text track content into text track cues for MPEG-4 ISOBMFF</dfn></p>
           <p>
             ISOBMFF text tracks may be in the WebVTT or TTML format [[ISO14496-30]], 3GPP Timed Text format [[3GPP-TT]], or other format.
           </p>


### PR DESCRIPTION
This removes the duplicate definition of "Mapping text track content into text track cues".
