### PR TITLE
Left-over references to a "text" field in DataCue.

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,8 +275,8 @@
                   <td>"false"</td>
                 </tr>
                 <tr>
-                  <th>text</th>
-                  <td>The (UTF-16 encoded) character array composing the ISD resource.</td>
+                  <th>data</th>
+                  <td>The (UTF-16 encoded) ArrayBuffer composing the ISD resource.</td>
                 </tr>
               </table>
             </p>
@@ -726,8 +726,8 @@
                   <td>"false"</td>
                 </tr>
                 <tr>
-                  <th>text</th>
-                  <td>The (UTF-16 encoded) character array composing the XML document.</td>
+                  <th>data</th>
+                  <td>The (UTF-16 encoded) ArrayBuffer composing the XML document.</td>
                 </tr>
               </table>
             </p>


### PR DESCRIPTION
Replace these with an ArrayBuffer "data" field.
