### PR TITLE
MPEG-2 TS captions without a caption_service_descriptor (bug 26778)

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,8 +342,14 @@
           <ul>
             <li>text track:
               <ul>
-                <li>The elementary stream with PID 0x02 or the stream type value is "0x02", "0x05", "0x80", between "0x82" and "0x86", or between "0x88 and 0xFF". </li>
-                <li><dfn id="captionservice">The CEA 708 caption service</dfn> [[CEA708]], as identified by a 'Caption Service Descriptor' [[ATSC65]] in the 'Elementary Stream Descriptors' in the PMT entry for a video stream with stream type 0x02 or 0x1B.</li>
+                <li>The elementary stream with PID 0x02 or the stream type value is "0x02", "0x05" or between "0x80" and "0xFF". </li>
+                <li><dfn id="captionservice">The CEA 708 caption service</dfn> [[CEA708]], as identified by:
+                  <ul>
+                    <li>A 'caption_service_descriptor' [[ATSC65]] in the 'Elementary Stream Descriptors' in the PMT entry for a video stream with stream type 0x02 or 0x1B.</li>
+                    <li>For 'stream_type' 0x02, the presence of caption data in the 'user_data()' field [[ATSC52]].</li>
+                    <li>For stream type 0x1B, the presence of caption data in the ‘ATSC1_data()’ field [[SCTE128-1]].</li>
+                  </ul>
+                </li>
               </ul>
             <li>video track: the stream type value is "0x01", "0x02", "0x10", "0x1B", or between "0x1E" and "0x23".</li>
             <li>audio track: the stream type value is "0x03", "0x04", "0x0F", "0x11", "0x1C", "0x81" or "0x87".</li>
@@ -385,7 +391,17 @@
               <th>language</th>
               <td>@kind is
                 <ul>
-                  <li>"captions": Content of the 'language' field for the caption service in the 'Caption Service Descriptor'.</li>
+                  <li>"captions":
+                    <ul>
+                      <li>Content of the 'language' field for the caption service in the 'caption_service_descriptor', if present.</li>
+                      <li>Otherwise:
+                        <ul>
+                          <li>For the first caption service, as identified by the 'service_number' field in the 'service_block' [[CEA708]] with a value of 1, the value of '@language' of the audio track where '@kind' has the value "main".</li>
+                          <li>The empty string for all other caption services, as identified by values greater than 1 in the 'service_number' field.</li>
+                        </ul>
+                      </li>
+                    </ul>
+                  </li>
                   <li>"subtitles": Content of the 'ISO_639_language_code' field in the 'ISO_639_language_descriptor' in the elementary stream descriptor array in the PMT.</li>
                   <li>"metadata": The empty string.</li>
                 </ul>


### PR DESCRIPTION
Resolves bug 26778. Adds text for recognizing captions when the caption_service_descriptor is missing.
